### PR TITLE
Bump CI actions and fix macOS arm64 incompatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
@@ -29,19 +29,16 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -55,7 +52,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - uses: julia-actions/cache@v3

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorGaussianMPS"
 uuid = "2be41995-7c9f-4653-b682-bfa4e7cebb93"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorGaussianMPS"
 uuid = "2be41995-7c9f-4653-b682-bfa4e7cebb93"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
-version = "0.1.14"
+version = "0.1.13"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
## Summary

- Bumps `julia-actions/setup-julia` from v2 to v3 and `codecov/codecov-action` from v5 to v6.
- Drops the hardcoded `arch: x64` from the test matrix. `macOS-latest` is now Apple Silicon — setup-julia v3 errors out on x64 requested against an arm64 runner (v2 merely warned), which is why #21 is failing CI. Letting setup-julia pick the default arch per runner matches the pattern used by the shared `ITensorActions/.github/workflows/Tests.yml` reusable workflow.

Supersedes #21 and #20.

## Test plan

- [ ] CI passes on ubuntu-latest (x64), macOS-latest (arm64 native), windows-latest (x64) for Julia lts and 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)