### PR TITLE
Inline DMRG output in README example

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorGaussianMPS"
 uuid = "2be41995-7c9f-4653-b682-bfa4e7cebb93"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,36 @@ println("\nRun dmrg with free fermion starting state")
 dmrg(H, ψ0; nsweeps = 4, maxdim = 60, cutoff = 1.0e-12)
 ````
 
+This will output something like:
+```
+(N, Nf) = (20, 10)
+U = 1.0
+
+Free fermion starting energy
+inner(ψ0', H, ψ0) = -2.3812770621299357
+
+Random state starting energy
+inner(ψr', H, ψr) = 10.0
+
+Run dmrg with random starting state
+After sweep 1 energy=6.261701784151 maxlinkdim=2 time=0.041
+After sweep 2 energy=2.844954346204 maxlinkdim=5 time=0.056
+After sweep 3 energy=0.245282430911 maxlinkdim=14 time=0.071
+After sweep 4 energy=-1.439072132586 maxlinkdim=32 time=0.098
+After sweep 5 energy=-2.220202191945 maxlinkdim=59 time=0.148
+After sweep 6 energy=-2.376787647893 maxlinkdim=60 time=0.186
+After sweep 7 energy=-2.381484153892 maxlinkdim=60 time=0.167
+After sweep 8 energy=-2.381489999291 maxlinkdim=57 time=0.233
+After sweep 9 energy=-2.381489999595 maxlinkdim=49 time=0.175
+After sweep 10 energy=-2.381489999595 maxlinkdim=49 time=0.172
+
+Run dmrg with free fermion starting state
+After sweep 1 energy=-2.381489929965 maxlinkdim=49 time=0.139
+After sweep 2 energy=-2.381489999588 maxlinkdim=49 time=0.165
+After sweep 3 energy=-2.381489999594 maxlinkdim=48 time=0.161
+After sweep 4 energy=-2.381489999594 maxlinkdim=48 time=0.169
+```
+
 ---
 
 *This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -103,3 +103,35 @@ dmrg(H, ψr; nsweeps = 10, maxdim = [10, 20, 40, 60], cutoff = 1.0e-12)
 
 println("\nRun dmrg with free fermion starting state")
 dmrg(H, ψ0; nsweeps = 4, maxdim = 60, cutoff = 1.0e-12)
+
+# This will output something like:
+#=
+```
+(N, Nf) = (20, 10)
+U = 1.0
+
+Free fermion starting energy
+inner(ψ0', H, ψ0) = -2.3812770621299357
+
+Random state starting energy
+inner(ψr', H, ψr) = 10.0
+
+Run dmrg with random starting state
+After sweep 1 energy=6.261701784151 maxlinkdim=2 time=0.041
+After sweep 2 energy=2.844954346204 maxlinkdim=5 time=0.056
+After sweep 3 energy=0.245282430911 maxlinkdim=14 time=0.071
+After sweep 4 energy=-1.439072132586 maxlinkdim=32 time=0.098
+After sweep 5 energy=-2.220202191945 maxlinkdim=59 time=0.148
+After sweep 6 energy=-2.376787647893 maxlinkdim=60 time=0.186
+After sweep 7 energy=-2.381484153892 maxlinkdim=60 time=0.167
+After sweep 8 energy=-2.381489999291 maxlinkdim=57 time=0.233
+After sweep 9 energy=-2.381489999595 maxlinkdim=49 time=0.175
+After sweep 10 energy=-2.381489999595 maxlinkdim=49 time=0.172
+
+Run dmrg with free fermion starting state
+After sweep 1 energy=-2.381489929965 maxlinkdim=49 time=0.139
+After sweep 2 energy=-2.381489999588 maxlinkdim=49 time=0.165
+After sweep 3 energy=-2.381489999594 maxlinkdim=48 time=0.161
+After sweep 4 energy=-2.381489999594 maxlinkdim=48 time=0.169
+```
+=#


### PR DESCRIPTION
## Summary

Follow-up to #23. The example in `examples/README.jl` runs DMRG but doesn't show the resulting output — the README just shows the code. Add an inlined expected-output block (using Literate's `#= \`\`\`…\`\`\` =#` idiom for "rendered but not executed") so readers can see what the code produces without running it.

Output values taken from the [legacy README.md](https://github.com/ITensor/ITensorGaussianMPS.jl/blob/f9b8e83/README.md) that existed before the template migration.

Regenerate `README.md` via `itpkgfmt` to pick up the change.

A later ecosystem change to `ITensorFormatter` may eventually flip `Literate.markdown(... execute = true)` so that these outputs are produced automatically, but that's tracked separately (`Projects/ITensorFormatter.jl/fixes_and_improvements` in ITensorDevelopmentPlans) and needs determinism handling first.

## Test plan

- [ ] Rendered README.md shows the output section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)